### PR TITLE
Active Record Encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+GOOGLE_SECRET='google secret'
+GOOGLE_KEY='google key'
+SESSION_SECRET='session secrete'
+COOKIE_SECRET='cookie secret'
+PRIMARY_KEY='primary key'
+DETERMINISTIC_KEY='deterministic key'
+KEY_DERIVATION_SALT='key derivation salt'

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,4 @@ stop:
 
 server:
 	docker compose up -d
-	docker exec -it sinatra /bin/sh -c "bin/setup \
-		&& bundle exec rackup --host 0.0.0.0 -p 4567"
+	docker exec -it sinatra /bin/sh -c "bundle exec rackup --host 0.0.0.0 -p 4567"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ COOKIE_SECRET='your_secret_key12345678901234567890123456789012345678901234567890
 make server
 ```
 
+## To generate 
+Add the keys above in .env:
+- PRIMARY_KEY
+- DETERMINISTIC_KEY
+- KEY_DERIVATION_SALT
+
+To generate them:
+```rake db:encryption:init```
+
 ## Tests
 ```
 rspec spec

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -2,6 +2,7 @@ require 'sinatra/activerecord'
 require 'bcrypt'
 
 class Session < ActiveRecord::Base
+  encrypts :email, deterministic: true
   validates :email, :expires_at, :session_id_digest, presence: true
 
   def initialize(attributes = {})
@@ -21,7 +22,7 @@ class Session < ActiveRecord::Base
   end
 
   def self.active_sessions(user_email)
-    where('email = ? AND expires_at >= ?', user_email, Time.now)
+    where(email: user_email).where('expires_at >= ?', Time.now)
   end
 
   def self.active_session(user_email)

--- a/db/database.rb
+++ b/db/database.rb
@@ -3,4 +3,10 @@ require 'sinatra/activerecord'
 
 set :database_file, '../database.yml'
 
+ActiveRecord::Encryption.configure(
+  primary_key: ENV['PRIMARY_KEY'],
+  deterministic_key: ENV['DETERMINISTIC_KEY'],
+  key_derivation_salt: ENV['KEY_DERIVATION_SALT']
+)
+
 require_relative '../app/models/session'


### PR DESCRIPTION
Este PR encriptografei o email.
Diferente da session_id, é possivel consultar e visualizar o email caso precise fazer alguma consulta no banco, mas ele não fica disponível nos logs, por exemplo.

Como foi apenas um estudo simples, resetei meu banco e criei novamente, não criei estrategias para lidar com sessions com e sem email criptografado.
 
Referencia:
https://edgeguides.rubyonrails.org/active_record_encryption.html